### PR TITLE
add report system

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(libs.checker)
 
     implementation(projects.codebookLvt)
+    api(projects.codebookReports)
 
     implementation(libs.guice)
     implementation(libs.inject)

--- a/codebook-lvt/build.gradle.kts
+++ b/codebook-lvt/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(platform(libs.hypo.platform))
+    implementation(projects.codebookReports)
 
     api(libs.checker)
     api(libs.bundles.hypo.base)

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtNamer.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtNamer.java
@@ -34,17 +34,15 @@ import dev.denwav.hypo.model.data.HypoKey;
 import dev.denwav.hypo.model.data.MethodData;
 import dev.denwav.hypo.model.data.types.JvmType;
 import dev.denwav.hypo.model.data.types.PrimitiveType;
+import io.papermc.codebook.report.Reports;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.cadixdev.lorenz.MappingSet;
 import org.cadixdev.lorenz.model.Mapping;
 import org.cadixdev.lorenz.model.MethodMapping;
@@ -61,12 +59,10 @@ public class LvtNamer {
     private final LvtTypeSuggester lvtTypeSuggester;
     private final RootLvtSuggester lvtAssignSuggester;
 
-    public final Map<String, AtomicInteger> missedNameSuggestions = new ConcurrentHashMap<>();
-
-    public LvtNamer(final HypoContext context, final MappingSet mappings) throws IOException {
+    public LvtNamer(final HypoContext context, final MappingSet mappings, final Reports reports) throws IOException {
         this.mappings = mappings;
         this.lvtTypeSuggester = new LvtTypeSuggester(context);
-        this.lvtAssignSuggester = new RootLvtSuggester(context, this.lvtTypeSuggester, this.missedNameSuggestions);
+        this.lvtAssignSuggester = new RootLvtSuggester(context, this.lvtTypeSuggester, reports);
     }
 
     public void processClass(final AsmClassData classData) throws IOException {

--- a/codebook-reports/build.gradle.kts
+++ b/codebook-reports/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-library`
+    id("codebook")
+}
+
+dependencies {
+    implementation(platform(libs.hypo.platform))
+
+    api(libs.checker)
+
+    implementation(libs.bundles.hypo.impl)
+    implementation(libs.bundles.asm)
+
+    implementation(libs.guice)
+    implementation(libs.inject)
+    implementation(libs.guava)
+}
+
+publishing {
+    publications {
+        codebook {
+            pom {
+                name.set("codebook-reports")
+                description.set("Codebook reports for PaperMC")
+            }
+        }
+    }
+}

--- a/codebook-reports/src/main/java/io/papermc/codebook/report/ReportType.java
+++ b/codebook-reports/src/main/java/io/papermc/codebook/report/ReportType.java
@@ -1,0 +1,28 @@
+/*
+ * codebook is a remapper utility for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 3 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.codebook.report;
+
+public enum ReportType {
+    MISSING_METHOD_LVT_SUGGESTION,
+    ;
+}

--- a/codebook-reports/src/main/java/io/papermc/codebook/report/Reports.java
+++ b/codebook-reports/src/main/java/io/papermc/codebook/report/Reports.java
@@ -1,0 +1,68 @@
+/*
+ * codebook is a remapper utility for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 3 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.codebook.report;
+
+import com.google.inject.AbstractModule;
+import io.papermc.codebook.report.type.MissingMethodLvtSuggestion;
+import io.papermc.codebook.report.type.Report;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class Reports extends AbstractModule {
+
+    private final Path reportsDir;
+    private final Set<ReportType> typesToGenerate;
+    private final Map<ReportType, Report> reports;
+
+    public Reports(final Path reportsDir, final Set<ReportType> typesToGenerate) {
+        this.reportsDir = reportsDir;
+        this.typesToGenerate = typesToGenerate;
+        this.reports = Map.of(ReportType.MISSING_METHOD_LVT_SUGGESTION, new MissingMethodLvtSuggestion());
+    }
+
+    public void generateReports() throws IOException {
+        Files.createDirectories(this.reportsDir);
+        for (final Entry<ReportType, Report> entry : this.reports.entrySet()) {
+            if (this.typesToGenerate.contains(entry.getKey())) {
+                final Path reportPath =
+                        this.reportsDir.resolve(entry.getKey().name().toLowerCase(Locale.ENGLISH) + ".txt");
+                Files.writeString(reportPath, entry.getValue().generate());
+            }
+        }
+    }
+
+    @Override
+    protected void configure() {
+        this.reports.values().forEach(this::bindReport);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <R extends Report> void bindReport(final R report) {
+        this.bind((Class<R>) report.getClass()).toInstance(report);
+    }
+}

--- a/codebook-reports/src/main/java/io/papermc/codebook/report/Reports.java
+++ b/codebook-reports/src/main/java/io/papermc/codebook/report/Reports.java
@@ -35,6 +35,19 @@ import java.util.Set;
 
 public class Reports extends AbstractModule {
 
+    @SuppressWarnings({"DataFlowIssue"})
+    public static final Reports NOOP = new Reports(null, Set.of()) {
+        @Override
+        public void generateReports() {
+            // NO-OP
+        }
+
+        @Override
+        protected void configure() {
+            // NO-OP
+        }
+    };
+
     private final Path reportsDir;
     private final Set<ReportType> typesToGenerate;
     private final Map<ReportType, Report> reports;

--- a/codebook-reports/src/main/java/io/papermc/codebook/report/type/MissingMethodLvtSuggestion.java
+++ b/codebook-reports/src/main/java/io/papermc/codebook/report/type/MissingMethodLvtSuggestion.java
@@ -1,0 +1,53 @@
+/*
+ * codebook is a remapper utility for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 3 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.codebook.report.type;
+
+import dev.denwav.hypo.model.data.MethodData;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.objectweb.asm.tree.MethodInsnNode;
+
+public class MissingMethodLvtSuggestion implements Report {
+
+    private static final Comparator<Map.Entry<String, AtomicInteger>> COMPARATOR =
+            Comparator.comparing(e -> e.getValue().get());
+
+    private final Map<String, AtomicInteger> data = new ConcurrentHashMap<>();
+
+    public void reportMissingMethodLvtSuggestion(final MethodData method, final MethodInsnNode insn) {
+        this.data
+                .computeIfAbsent(method.name() + "," + insn.owner + "," + insn.desc, (k) -> new AtomicInteger(0))
+                .incrementAndGet();
+    }
+
+    @Override
+    public String generate() {
+        final StringBuilder output = new StringBuilder();
+        this.data.entrySet().stream()
+                .sorted(COMPARATOR.reversed())
+                .forEach(s -> output.append("missed: %s -- %s times%n".formatted(s.getKey(), s.getValue())));
+        return output.toString();
+    }
+}

--- a/codebook-reports/src/main/java/io/papermc/codebook/report/type/Report.java
+++ b/codebook-reports/src/main/java/io/papermc/codebook/report/type/Report.java
@@ -1,0 +1,28 @@
+/*
+ * codebook is a remapper utility for the PaperMC project.
+ *
+ * Copyright (c) 2023 Kyle Wood (DenWav)
+ *                    Contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 3 only, no later versions.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.papermc.codebook.report.type;
+
+public interface Report {
+
+    String generate();
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,5 +6,6 @@ rootProject.name = "codebook"
 
 include("codebook-cli")
 include("codebook-lvt")
+include("codebook-reports")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/src/main/java/io/papermc/codebook/CodeBook.java
+++ b/src/main/java/io/papermc/codebook/CodeBook.java
@@ -43,6 +43,7 @@ import io.papermc.codebook.pages.RemapJarPage;
 import io.papermc.codebook.pages.RemapLvtPage;
 import io.papermc.codebook.pages.UnpickPage;
 import io.papermc.codebook.util.IOUtil;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -95,6 +96,13 @@ public final class CodeBook {
         }
 
         IOUtil.move(resultJar, this.ctx.outputJar());
+        if (this.ctx.reports() != null) {
+            try {
+                this.ctx.reports().generateReports();
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     private static Injector injector(final Module module) {
@@ -171,6 +179,13 @@ public final class CodeBook {
                     this.bind(CodeBookPage.ConstantsJar.KEY).toInstance(constantsJar);
                 } else {
                     this.bind(CodeBookPage.ConstantsJar.KEY).toProvider(Providers.of(null));
+                }
+
+                if (CodeBook.this.ctx.reports() != null) {
+                    this.bind(CodeBookPage.Report.KEY).toInstance(CodeBook.this.ctx.reports());
+                    this.install(CodeBook.this.ctx.reports());
+                } else {
+                    this.bind(CodeBookPage.Report.KEY).toProvider(Providers.of(null));
                 }
             }
         };

--- a/src/main/java/io/papermc/codebook/CodeBook.java
+++ b/src/main/java/io/papermc/codebook/CodeBook.java
@@ -42,6 +42,7 @@ import io.papermc.codebook.pages.InspectJarPage;
 import io.papermc.codebook.pages.RemapJarPage;
 import io.papermc.codebook.pages.RemapLvtPage;
 import io.papermc.codebook.pages.UnpickPage;
+import io.papermc.codebook.report.Reports;
 import io.papermc.codebook.util.IOUtil;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -185,7 +186,8 @@ public final class CodeBook {
                     this.bind(CodeBookPage.Report.KEY).toInstance(CodeBook.this.ctx.reports());
                     this.install(CodeBook.this.ctx.reports());
                 } else {
-                    this.bind(CodeBookPage.Report.KEY).toProvider(Providers.of(null));
+                    this.bind(CodeBookPage.Report.KEY).toInstance(Reports.NOOP);
+                    this.install(Reports.NOOP);
                 }
             }
         };

--- a/src/main/java/io/papermc/codebook/config/CodeBookContext.java
+++ b/src/main/java/io/papermc/codebook/config/CodeBookContext.java
@@ -22,6 +22,7 @@
 
 package io.papermc.codebook.config;
 
+import io.papermc.codebook.report.Reports;
 import io.soabase.recordbuilder.core.RecordBuilder;
 import java.nio.file.Path;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -41,7 +42,7 @@ public record CodeBookContext(
         @NotNull Path outputJar,
         boolean overwrite,
         @NotNull CodeBookInput input,
-        boolean logMissingLvtSuggestions) {
+        @Nullable @org.jetbrains.annotations.Nullable Reports reports) {
 
     public static CodeBookContextBuilder builder() {
         return CodeBookContextBuilder.builder();

--- a/src/main/java/io/papermc/codebook/pages/CodeBookPage.java
+++ b/src/main/java/io/papermc/codebook/pages/CodeBookPage.java
@@ -31,6 +31,7 @@ import com.google.inject.util.Modules;
 import com.google.inject.util.Providers;
 import dev.denwav.hypo.core.HypoContext;
 import io.papermc.codebook.config.CodeBookContext;
+import io.papermc.codebook.report.Reports;
 import jakarta.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -155,5 +156,12 @@ public abstract class CodeBookPage {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Hypo {
         Key<HypoContext> KEY = Key.get(HypoContext.class, Hypo.class);
+    }
+
+    @Qualifier
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Report {
+        Key<Reports> KEY = Key.get(Reports.class, Report.class);
     }
 }

--- a/src/test/java/io/papermc/codebook/lvt/LvtAssignmentSuggesterTest.java
+++ b/src/test/java/io/papermc/codebook/lvt/LvtAssignmentSuggesterTest.java
@@ -42,9 +42,9 @@ import dev.denwav.hypo.model.data.types.JvmType;
 import io.papermc.codebook.lvt.suggestion.context.ContainerContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodCallContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodInsnContext;
+import io.papermc.codebook.report.Reports;
 import java.io.IOException;
 import java.util.EnumSet;
-import java.util.HashMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +82,9 @@ class LvtAssignmentSuggesterTest {
     @Mock
     private ClassData randomSourceClass;
 
+    @Mock
+    private Reports reports;
+
     @BeforeEach
     void setup() throws Exception {
         final HypoContext context =
@@ -95,7 +98,7 @@ class LvtAssignmentSuggesterTest {
 
         when(this.randomSourceClass.name()).thenReturn(RANDOM_SOURCE_TYPE.asInternalName());
 
-        this.suggester = new RootLvtSuggester(context, new LvtTypeSuggester(context), new HashMap<>());
+        this.suggester = new RootLvtSuggester(context, new LvtTypeSuggester(context), this.reports);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Creates a general injectable system for creating reports that can be generated via the CLI or by using the library directly. Should be helpful for generating separate logs of any important information from any point in codebook without having 1 big log file.

It's possible this should just be done with separate loggers that point to different files, but I like this because it creates a more abstract way on how formatting of various information would look.