### PR TITLE
Fix handling of capitalization in class types

### DIFF
--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtTypeSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtTypeSuggester.java
@@ -116,7 +116,7 @@ public final class LvtTypeSuggester {
         final String baseName = name.substring(1, name.length() - 1);
         final String simpleName = getSimpleName(baseName);
 
-        return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+        return LvtUtil.parseSimpleTypeName(simpleName);
     }
 
     private static final Splitter dollarSplitter = Splitter.on('$');

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
@@ -150,4 +150,16 @@ public final class LvtUtil {
         // myCoolAABBClass -> myCoolAabbClass
         return LvtUtil.pruneLeadingCapitals(name);
     }
+
+    @Nullable
+    public static String parseSimpleTypeNameFromMethod(final String methodName, int prefix) {
+        if (!Character.isUpperCase(methodName.charAt(prefix))) {
+            // If the char isn't uppercase, that means it isn't following the typical `lowerCamelCase`
+            // Java method naming scheme how we expect, so we can't be sure it means what we think it
+            // means in this instance
+            return null;
+        } else {
+            return LvtUtil.parseSimpleTypeName(methodName.substring(prefix));
+        }
+    }
 }

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
@@ -135,12 +135,8 @@ public final class LvtUtil {
             return simpleName.toLowerCase();
         }
 
-        // Proper case!
+        // Decapitalize
         // HelloWorld -> helloWorld
-        // BigCrazy -> bigCrazy
-        //final String name = Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
-
-        // Parse leading capitals
         // abstractUUIDFix -> abstractUuidFix
         // myCoolAABBClass -> myCoolAabbClass
         return LvtUtil.decapitalize(simpleName);

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
@@ -41,6 +41,29 @@ public final class LvtUtil {
         return Character.toUpperCase(name.charAt(index)) + name.substring(index + 1);
     }
 
+    public static String pruneLeadingCapitals(final String name) {
+        boolean capturingGroup = true;
+        final StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < name.length(); i++) {
+            final char character = name.charAt(i);
+            if (Character.isUpperCase(character)) {
+                if (capturingGroup) {
+                    // Convert the leading capital to lowercase and append to the result
+                    result.append(Character.toLowerCase(character));
+                } else {
+                    capturingGroup = true;
+                    result.append(character);
+                }
+            } else {
+                capturingGroup = false;
+                result.append(character);
+            }
+        }
+
+        return result.toString();
+    }
+
     public static @Nullable String decapitalize(final String name, final int index) {
         if (!Character.isUpperCase(name.charAt(index))) {
             // If the char isn't uppercase, that means it isn't following the typical `lowerCamelCase`
@@ -107,5 +130,24 @@ public final class LvtUtil {
 
     public static boolean hasPrefix(final String text, final String prefix) {
         return text.length() > prefix.length() && text.startsWith(prefix);
+    }
+
+    public static String parseSimpleTypeName(final String simpleName) {
+        // Parse all capitalized types into lowercase
+        // UUID -> uuid
+        // AABB -> aabb
+        if (LvtUtil.isStringAllUppercase(simpleName)) {
+            return simpleName.toLowerCase();
+        }
+
+        // Proper case!
+        // HelloWorld -> helloWorld
+        // BigCrazy -> bigCrazy
+        final String name = Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+
+        // Parse leading capitals
+        // abstractUUIDFix -> abstractUuidFix
+        // myCoolAABBClass -> myCoolAabbClass
+        return LvtUtil.pruneLeadingCapitals(name);
     }
 }

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
@@ -41,19 +41,25 @@ public final class LvtUtil {
         return Character.toUpperCase(name.charAt(index)) + name.substring(index + 1);
     }
 
-    public static String pruneLeadingCapitals(final String name) {
-        boolean capturingGroup = true;
+    public static String decapitalize(final String name) {
+        boolean capturingGroup = false;
         final StringBuilder result = new StringBuilder();
 
         for (int i = 0; i < name.length(); i++) {
             final char character = name.charAt(i);
             if (Character.isUpperCase(character)) {
                 if (capturingGroup) {
-                    // Convert the leading capital to lowercase and append to the result
-                    result.append(Character.toLowerCase(character));
+                    if (i < name.length() - 1 && Character.isLowerCase(name.charAt(i + 1))) {
+                        // Next char is lowercase, so this is the start of a new word
+                        result.append(character);
+                    } else {
+                        // Convert the leading capital to lowercase and append to the result
+                        result.append(Character.toLowerCase(character));
+                    }
                 } else {
+                    // let's start a group, making sure to lowercase if it's the first char of the name
                     capturingGroup = true;
-                    result.append(character);
+                    result.append(i == 0 ? Character.toLowerCase(character) : character);
                 }
             } else {
                 capturingGroup = false;
@@ -62,17 +68,6 @@ public final class LvtUtil {
         }
 
         return result.toString();
-    }
-
-    public static @Nullable String decapitalize(final String name, final int index) {
-        if (!Character.isUpperCase(name.charAt(index))) {
-            // If the char isn't uppercase, that means it isn't following the typical `lowerCamelCase`
-            // Java method naming scheme how we expect, so we can't be sure it means what we think it
-            // means in this instance
-            return null;
-        } else {
-            return Character.toLowerCase(name.charAt(index)) + name.substring(index + 1);
-        }
     }
 
     public static Predicate<String> equalsAny(final String... strings) {
@@ -143,12 +138,12 @@ public final class LvtUtil {
         // Proper case!
         // HelloWorld -> helloWorld
         // BigCrazy -> bigCrazy
-        final String name = Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+        //final String name = Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
 
         // Parse leading capitals
         // abstractUUIDFix -> abstractUuidFix
         // myCoolAABBClass -> myCoolAabbClass
-        return LvtUtil.pruneLeadingCapitals(name);
+        return LvtUtil.decapitalize(simpleName);
     }
 
     @Nullable

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/NewPrefixSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/NewPrefixSuggester.java
@@ -22,8 +22,8 @@
 
 package io.papermc.codebook.lvt.suggestion;
 
-import static io.papermc.codebook.lvt.LvtUtil.decapitalize;
 import static io.papermc.codebook.lvt.LvtUtil.hasPrefix;
+import static io.papermc.codebook.lvt.LvtUtil.parseSimpleTypeNameFromMethod;
 
 import io.papermc.codebook.lvt.suggestion.context.ContainerContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodCallContext;
@@ -53,6 +53,6 @@ public class NewPrefixSuggester implements LvtSuggester {
             return result;
         }
 
-        return decapitalize(methodName, 3);
+        return parseSimpleTypeNameFromMethod(methodName, 3);
     }
 }

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/SingleVerbSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/SingleVerbSuggester.java
@@ -22,10 +22,9 @@
 
 package io.papermc.codebook.lvt.suggestion;
 
-import static io.papermc.codebook.lvt.LvtUtil.decapitalize;
+import static io.papermc.codebook.lvt.LvtUtil.parseSimpleTypeNameFromMethod;
 import static io.papermc.codebook.lvt.LvtUtil.tryMatchPrefix;
 
-import io.papermc.codebook.lvt.LvtUtil;
 import io.papermc.codebook.lvt.suggestion.context.ContainerContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodCallContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodInsnContext;
@@ -50,6 +49,6 @@ public class SingleVerbSuggester implements LvtSuggester {
             return null;
         }
 
-        return LvtUtil.parseSimpleTypeName(methodName.substring(prefix.length()));
+        return parseSimpleTypeNameFromMethod(methodName, prefix.length());
     }
 }

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/SingleVerbSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/SingleVerbSuggester.java
@@ -25,6 +25,7 @@ package io.papermc.codebook.lvt.suggestion;
 import static io.papermc.codebook.lvt.LvtUtil.decapitalize;
 import static io.papermc.codebook.lvt.LvtUtil.tryMatchPrefix;
 
+import io.papermc.codebook.lvt.LvtUtil;
 import io.papermc.codebook.lvt.suggestion.context.ContainerContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodCallContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodInsnContext;
@@ -49,6 +50,6 @@ public class SingleVerbSuggester implements LvtSuggester {
             return null;
         }
 
-        return decapitalize(methodName, prefix.length());
+        return LvtUtil.parseSimpleTypeName(methodName.substring(prefix.length()));
     }
 }

--- a/src/test/resources/io/papermc/codebook/lvt/LvtAssignmentSuggesterTest.csv
+++ b/src/test/resources/io/papermc/codebook/lvt/LvtAssignmentSuggesterTest.csv
@@ -8,6 +8,7 @@ freeze,net/minecraft/core/RegistryAccess,()Lnet/minecraft/core/RegistryAccess.Fr
 getName,io/paper/Paper,()Ljava/lang/String;,name
 getSuperLongDumName,io/paper/Paper,()Ljava/lang/String;,superLongDumName
 getOrCreateSomething,io/paper/Paper,()Ljava/lang/String;,something
+getUUID,io/paper/Paper,()Ljava/util/UUID;,uuid
 # as
 asString,io/paper/Paper,()Ljava/lang/String;,string
 asLevel,io/paper/paper,()Lnet/minecraft/Level;,level

--- a/src/test/resources/io/papermc/codebook/lvt/LvtAssignmentSuggesterTest.csv
+++ b/src/test/resources/io/papermc/codebook/lvt/LvtAssignmentSuggesterTest.csv
@@ -76,3 +76,8 @@ nextIntBetween,net/minecraft/util/RandomSource,(II)J,
 nextBoolean,net/minecraft/util/RandomSource,()Z,randomBoolean
 nextInt,net/minecraft/util/Mth,(Lnet/minecraft/util/RandomSource;)I,randomInt
 nextInt,net/minecraft/util/Mth,(I)I,
+# capitalization tests
+getDOMSource,io/paper/DOMSource,()Lio/paper/DOMSource;,domSource
+getThreadMXBean,java/lang/ManagementFactory,()Ljava/lang/management/ThreadMXBean;,threadMxBean
+getSectionYFromSectionIndex,net/minecraft/world/level/chunk/LevelChunkSection,()I,sectionYFromSectionIndex
+getLinkFSPath,io/paper/LinkFSPath,()Lio/paper/LinkFSPath;,linkFsPath


### PR DESCRIPTION
Before:
<img width="829" alt="Screenshot 2023-09-12 at 11 03 15 PM" src="https://github.com/PaperMC/codebook/assets/23108066/8fece00b-e66e-44db-8cdb-fbf08ffe33ec">
After:
<img width="846" alt="Screenshot 2023-09-12 at 11 03 37 PM" src="https://github.com/PaperMC/codebook/assets/23108066/57ba5eef-df10-4be5-be8c-6974b3167d97">


In general, capital crazy classes will be less aggressive now.
Most notiably, types of `UUID` will now be `uuid` rather than `uUID`

Before:
``uUid, aABB, abstractUUIDFix``

After:
``uuid, aabb, abstractUuidFix``