### PR TITLE
restore naming nbt collections by their concrete type rather than 'list'

### DIFF
--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtTypeSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtTypeSuggester.java
@@ -102,9 +102,9 @@ public final class LvtTypeSuggester {
         }
 
         // TODO Try to determine name from signature, rather than just descriptor
-        final @Nullable ClassData typeClass = context.getContextProvider().findClass(type);
+        final @Nullable ClassData typeClass = this.context.getContextProvider().findClass(type);
         if (typeClass != null) {
-            if (typeClass.doesExtendOrImplement(this.listClass)) {
+            if (typeClass.doesExtendOrImplement(this.listClass) && !typeClass.name().startsWith("net/minecraft/nbt/")) { // exclude nbt lists
                 return "list";
             } else if (typeClass.doesExtendOrImplement(this.setClass)) {
                 return "set";


### PR DESCRIPTION
Fixes a regression caused by the migration to the modular suggester system.