### PR TITLE
Improve naming for min/max for loops

### DIFF
--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/FluentGetterSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/FluentGetterSuggester.java
@@ -27,6 +27,7 @@ import io.papermc.codebook.lvt.suggestion.context.ContainerContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodCallContext;
 import io.papermc.codebook.lvt.suggestion.context.method.MethodInsnContext;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.IntPredicate;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -90,7 +91,8 @@ public class FluentGetterSuggester implements LvtSuggester {
             if (ignored.contains(name)) {
                 return null;
             }
-            return name;
+            final @Nullable String forLoopAdjustedName = SingleVerbSuggester.handleForLoop(name, insn, "min", "max");
+            return Objects.requireNonNullElse(forLoopAdjustedName, name);
         }
         return null;
     }

--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/SingleVerbSuggester.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/suggestion/SingleVerbSuggester.java
@@ -56,7 +56,8 @@ public class SingleVerbSuggester implements LvtSuggester {
         return newName != null ? newName : parseSimpleTypeNameFromMethod(methodName, prefix.length());
     }
 
-    public static @Nullable String handleForLoop(final String methodName, final MethodInsnContext insn, final String minPrefix, final String maxPrefix) {
+    public static @Nullable String handleForLoop(
+            final String methodName, final MethodInsnContext insn, final String minPrefix, final String maxPrefix) {
         @Nullable String newName = handleForLoopPrefix(methodName, insn.node(), minPrefix, maxPrefix);
         if (newName == null) {
             newName = handleForLoopPrefix(methodName, insn.node(), maxPrefix, minPrefix);
@@ -64,11 +65,14 @@ public class SingleVerbSuggester implements LvtSuggester {
         return newName;
     }
 
-    private static @Nullable String handleForLoopPrefix(final String methodName, final MethodInsnNode methodInsnNode, final String first, final String second) {
+    private static @Nullable String handleForLoopPrefix(
+            final String methodName, final MethodInsnNode methodInsnNode, final String first, final String second) {
         if (methodName.startsWith(first)) {
-            @Nullable AbstractInsnNode nextInsn = methodInsnNode.getNext(); // look for getMin/MaxXXX call on the same line
+            @Nullable
+            AbstractInsnNode nextInsn = methodInsnNode.getNext(); // look for getMin/MaxXXX call on the same line
             while (nextInsn != null && !(nextInsn instanceof LineNumberNode)) {
-                if (nextInsn instanceof final MethodInsnNode afterMethodInvoke && afterMethodInvoke.name.startsWith(second)) {
+                if (nextInsn instanceof final MethodInsnNode afterMethodInvoke
+                        && afterMethodInvoke.name.startsWith(second)) {
                     return parseSimpleTypeNameFromMethod(methodName, first.length());
                 }
                 nextInsn = nextInsn.getNext();


### PR DESCRIPTION
The `getMin...`/`getMax...` methods made loop variables named poorly, as it should not include the `min` or `max` part in the name since it is being incremented. This detects if a getMin and getMax call are on the same line, which means they are most likely part of a for loop. If there is a better way to detect that, I can change it.