### PR TITLE
Correctly lowercase lvt

### DIFF
--- a/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
+++ b/codebook-lvt/src/main/java/io/papermc/codebook/lvt/LvtUtil.java
@@ -138,7 +138,7 @@ public final class LvtUtil {
         // UUID -> uuid
         // AABB -> aabb
         if (LvtUtil.isStringAllUppercase(simpleName)) {
-            return simpleName.toLowerCase();
+            return simpleName.toLowerCase(Locale.ROOT);
         }
 
         // Decapitalize


### PR DESCRIPTION
Codebook uses toLowerCase for fully upper-cased type names like UUID.
The call uses the default locale, which might incorrectly map characters
like 'I' to lowercase versions that are not 'i'.
This prevents further patching of the mache sources.

Correctly specify the ROOT locale instead, making the logic independent
from the JVM default locale.
